### PR TITLE
Fix being unable to rewrite service/importer/inventory.php

### DIFF
--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Factory/Service/Importer.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Factory/Service/Importer.php
@@ -17,10 +17,10 @@ class SixBySix_RealTimeDespatch_Model_Factory_Service_Importer
     {
         switch ($type) {
             case self::IMPORTER_INVENTORY:
-                return new SixBySix_RealTimeDespatch_Model_Service_Importer_Inventory;
+                return Mage::getModel('realtimedespatch/service_importer_inventory');
             break;
             case self::IMPORTER_SHIPMENT:
-                return new SixBySix_RealTimeDespatch_Model_Service_Importer_Shipment;
+                return Mage::getModel('realtimedespatch/service_importer_shipment');
             break;
             default:
                 throw new Exception('Invalid Importer Type');


### PR DESCRIPTION
Change to conform to Magento standards, was trying to rewrite the importer inventory class to find the above was a direct php call rather than using Magento's getModel(). Can now rewrite the classes via XML using getModel instead of PHP class call.
