### PR TITLE
Fix multiselect/dropdown attribute type export

### DIFF
--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
@@ -45,10 +45,10 @@ class SixBySix_RealTimeDespatch_Model_Mapper_Products extends Mage_Core_Helper_A
             try {
 	            $attribute = $product->getResource()->getAttribute($magentoKey);
 	            if($attribute != false && in_array($attribute->getFrontendInput(), $attributeTypes)) {
-		            $encodedProduct->setParam($rtdKey, $product->getAttributeText($magentoKey));
+			$encodedProduct->setParam($rtdKey, $product->getAttributeText($magentoKey));
 	            }
 	            else {
-		            $encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
+			$encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
 	            }
             }
             catch (Exception $ex) {

--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
@@ -39,10 +39,17 @@ class SixBySix_RealTimeDespatch_Model_Mapper_Products extends Mage_Core_Helper_A
     {
         $encodedProduct = new RTDProduct;
         $customMapping  = Mage::getConfig()->getNode('rtd_mappings/product/export');
+	    $attributeTypes = array('multiselect', 'dropdown');
 
         foreach ($customMapping->asArray() as $magentoKey => $rtdKey) {
             try {
-                $encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
+	            $attribute = $product->getResource()->getAttribute($magentoKey);
+	            if($attribute != false && in_array($attribute->getFrontendInput(), $attributeTypes)) {
+		            $encodedProduct->setParam($rtdKey, $product->getAttributeText($magentoKey));
+	            }
+	            else {
+		            $encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
+	            }
             }
             catch (Exception $ex) {
                 Mage::log($ex->getMessage(), null, 'realtimedespatch.log');
@@ -50,7 +57,6 @@ class SixBySix_RealTimeDespatch_Model_Mapper_Products extends Mage_Core_Helper_A
         }
 
         $this->_swapPlaceholderWithParentImage($product, $encodedProduct);
-
         return $encodedProduct;
     }
 

--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Mapper/Products.php
@@ -39,17 +39,17 @@ class SixBySix_RealTimeDespatch_Model_Mapper_Products extends Mage_Core_Helper_A
     {
         $encodedProduct = new RTDProduct;
         $customMapping  = Mage::getConfig()->getNode('rtd_mappings/product/export');
-	    $attributeTypes = array('multiselect', 'dropdown');
+	$attributeTypes = array('multiselect', 'dropdown');
 
         foreach ($customMapping->asArray() as $magentoKey => $rtdKey) {
             try {
-	            $attribute = $product->getResource()->getAttribute($magentoKey);
-	            if($attribute != false && in_array($attribute->getFrontendInput(), $attributeTypes)) {
-			$encodedProduct->setParam($rtdKey, $product->getAttributeText($magentoKey));
-	            }
-	            else {
-			$encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
-	            }
+	        $attribute = $product->getResource()->getAttribute($magentoKey);
+	        if($attribute != false && in_array($attribute->getFrontendInput(), $attributeTypes)) {
+		    $encodedProduct->setParam($rtdKey, $product->getAttributeText($magentoKey));
+	        }
+	        else {
+		    $encodedProduct->setParam($rtdKey, $product->{'get'.$magentoKey}());
+	        }
             }
             catch (Exception $ex) {
                 Mage::log($ex->getMessage(), null, 'realtimedespatch.log');


### PR DESCRIPTION
Currently the functionality will output the option_id to the XML when accessing data held within a multiselect or dropdown attribute type, the updated function modifies this so it will grab the text value from the option_id and output this instead, while retaining the original functionality for other attribute types.
