### PR TITLE
Inventory Event and Order Export Validation Feature

### DIFF
--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
@@ -79,6 +79,12 @@ class SixBySix_RealTimeDespatch_Model_Service_Importer_Inventory extends SixBySi
                     $sku,
                     'Product Quantity Successfully Updated to '.$body->value
                 );
+                
+                // Only fire pre-instantiated objects to reduce overhead.
+                $productArray = array('product_id' => $productId,
+	                              'stock' => $stock);
+		
+	        Mage::dispatchEvent('catalog_product_stock_save_after', $productArray);
             }
             catch (Exception $ex)
             {
@@ -90,12 +96,6 @@ class SixBySix_RealTimeDespatch_Model_Service_Importer_Inventory extends SixBySi
                 );
             }
         }
-        
-        // Only fire pre-instantiated objects to reduce overhead.
-        $productArray = array('product_id' => $productId,
-	                          'stock' => $stock);
-
-	    Mage::dispatchEvent('catalog_product_stock_save_after', $productArray);
 
         $report->setLines($reportLines);
 

--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Importer/Inventory.php
@@ -90,6 +90,12 @@ class SixBySix_RealTimeDespatch_Model_Service_Importer_Inventory extends SixBySi
                 );
             }
         }
+        
+        // Only fire pre-instantiated objects to reduce overhead.
+        $productArray = array('product_id' => $productId,
+	                          'stock' => $stock);
+
+	    Mage::dispatchEvent('catalog_product_stock_save_after', $productArray);
 
         $report->setLines($reportLines);
 

--- a/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Validation.php
+++ b/app/code/community/SixBySix/RealTimeDespatch/Model/Service/Validation.php
@@ -1,0 +1,105 @@
+<?php
+
+	/**
+	 * Class SixBySix_RealTimeDespatch_Model_Service_Validation
+	 * Note that this class should be executed from the Magento-root/shell folder, as to bypass Magento cron in case it
+	 * stalls.
+	 */
+
+	class SixBySix_RealTimeDespatch_Model_Service_Validation extends Mage_Core_Model_Abstract {
+
+		/**
+		 * Constructors that are used.
+		 */
+		public function __construct()
+		{
+			parent::__construct();
+			$this->adminEmail = Mage::getStoreConfig('sixbysix_realtimedespatch/general/admin_email');
+			$this->adminName = Mage::getStoreConfig('sixbysix_realtimedespatch/general/admin_name');
+			$this->list = Mage::getStoreConfig('sixbysix_realtimedespatch/error_notification/list_users');
+
+		}
+
+		/**
+		 * @return bool
+		 * Author: Adam Hall (adamhall@dobell.co.uk)
+		 * Checks exported orders via SQL query to make sure threshold level hasn't been exceeded.
+		 */
+		function checkExportedOrders()
+		{
+			$resource = Mage::getSingleton('core/resource');
+			$db = $resource->getConnection('core_read');
+			$enable = Mage::getStoreConfig('sixbysix_realtimedespatch/error_notification/is_enabled');
+			$threshold = (int)Mage::getStoreConfig('sixbysix_realtimedespatch/error_notification/exceedsize');
+
+			if($enable == false) {
+				return true;
+			}
+
+			$list = $this->appendList();
+
+			// Check the grid table, we could check the order flat table but either is fine. Count the results.
+			$query = $db->select()->from(array('sales_flat_order_grid'),
+			                             'count(*)')
+				->where('is_exported = ?', false)
+				->where('status = \'processing\'');
+
+			$count = (int)$db->fetchOne($query);
+
+			if($count >= $threshold)
+			{
+				$mail = new Zend_Mail('UTF-8');
+
+				$mail->setBodyHtml($this->bodyHtmlExported($threshold))
+					->setType(Zend_Mime::MULTIPART_MIXED)
+					->setFrom('admin@' . Mage::app()->getRequest()->getHttpHost(), Mage::app()->getStore(0)->getName())
+					->addTo($list)
+					->setSubject('Order Export Failure, Threshold Exceeded');
+
+				$mail->send();
+				return false;
+			}
+			else {
+				return true;
+			}
+		}
+
+		/**
+		 * Author: Adam Hall (adamhall@dobell.co.uk)
+		 * Get admin users and create a list that can be inserted into Zend_Mail.
+		 * @return array
+		 */
+		private function appendList()
+		{
+			$list = $this->list;
+			// Add list of users from backend + admin user.
+			if(strpos($list, ',')) {
+				$list = explode(',', $list);
+				$list[$this->adminName] = $this->adminEmail;
+			}
+			// If we just have one address in the admin users list.
+			elseif(!empty($list)) {
+				$list = array($list);
+				$list[$this->adminName] = $this->adminEmail;
+			}
+			// Just use the admin users address.
+			else {
+				$list[$this->adminName] = $this->adminEmail;
+			}
+			return $list;
+		}
+
+		/**
+		 * @param $threshold
+		 * @return string Author: Adam Hall (adamhall@dobell.co.uk)
+		 * Author: Adam Hall (adamhall@dobell.co.uk)
+		 * Body HTML text for email to be sent.
+		 */
+		private function bodyHtmlExported($threshold)
+		{
+			return 'Dear Admin,<br><br>
+			<strong>WARNING:</strong> There are now more than ' . $threshold .' orders that haven\'t been exported to Orderflow yet, please investigate the Magento cron.<br><br>
+			This is an automated email, please do not reply.';
+		}
+
+	}

--- a/app/code/community/SixBySix/RealTimeDespatch/etc/system.xml
+++ b/app/code/community/SixBySix/RealTimeDespatch/etc/system.xml
@@ -347,7 +347,47 @@
                             <show_in_store>0</show_in_store>
                         </is_enabled>
                     </fields>                                   
-                </admin_info>               
+                </admin_info>
+                <error_notification>
+                    <label>Error Notification</label>
+                    <frontend_type>text</frontend_type>
+                    <comment>This feature requires the server level cronjob to execute this, please see instructions and pass these to a system administrator for implementation.</comment>
+                    <sort_order>1000</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>0</show_in_website>
+                    <show_in_store>0</show_in_store>
+                    <fields>
+                        <is_enabled translate="label">
+                            <label>Order Export Validation</label>
+                            <frontend_type>select</frontend_type>
+                            <comment>Enable this to recieve emails when the order export stalls.</comment>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>1</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </is_enabled>
+                        <exceedsize>
+                            <label>Email when..</label>
+                            <frontend_type>number</frontend_type>
+                            <comment>or more exports have stacked up without being sent down to Orderflow.</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>2</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </exceedsize>
+                        <list_users>
+                            <label>Users to email</label>
+                            <comment>Add a comma delimited list of users to email in the event the cron stops working, admin contact will be automatically included.</comment>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>3</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </list_users>
+                    </fields>
+                </error_notification>
             </groups>
         </sixbysix_realtimedespatch>
     </sections>

--- a/shell/order_export_check.php
+++ b/shell/order_export_check.php
@@ -1,0 +1,5 @@
+<?php
+
+	require_once '../app/Mage.php';
+	Mage::app();
+	Mage::getModel('realtimedespatch/service_validation')->checkExportedOrders();


### PR DESCRIPTION
Few additions with this pull request.

First, I have written a custom caching module for our web store, and I needed a way to invalidate cache on inventory update. So I added an event when an inventory update is processed so that this can be used to invalidate cache.

Furthermore, I have added a feature for when the Magento cron stalls, this happens a few times a year (however at the moment it is far more often due to some buggy community code interacting with Enterprise). Due to having to rely on warehouse staff noticing this (good example - we had a 4 hour gap, with a 100 + orders not being exported in that time), it can lead to orders not going out of the door when they should have.

So in light of this; what this does, is there is a shell script that needs to be added to the server level cron job, which is executed based on the cron expression setup by a system administrator. If it detects more than a predefined level that is set in the orderflow system configuration, then it emails the admin user as well as any other users that are setup in the configuration. There is an on/off configuration for this as well.

This circumvents the Magento cron in the event it stalls, and is extremely useful for us as a business at least, will leave it up to you guys if you would like to merge this pull request but figured it would be handy to other Orderflow uses in the event the cron stalls.
